### PR TITLE
chore(filmotheque-back): Removed engine-strict directive and change dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'thursday'
+      day: 'wednesday'
       time: '08:00'
       timezone: 'Europe/Madrid'
     open-pull-requests-limit: 10

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
### What's new

No new features added.

### What's fixed

- Removed `.npmrc` file due to incompatibilities with PNPM and dependabot
- Changed dependabot schedule

### How to test

- Check out that dependabot doesn't fail

### Breaking changes

No breaking changes...
